### PR TITLE
add additional annotation that can occur in module descriptor

### DIFF
--- a/CeylonModule.tmLanguage
+++ b/CeylonModule.tmLanguage
@@ -56,7 +56,7 @@
 
 		<dict>
 			<key>match</key>
-			<string>\b(doc|by|deprecated|shared)\b</string>	
+			<string>\b(doc|by|license|see|throws|tagged|deprecated|shared|optional|suppressWarnings)\b</string>	
 			<key>name</key>
 			<string>keyword.other.ceylon</string>
 		</dict>


### PR DESCRIPTION
These extra annotations can occur in `module.ceylon`.