### PR TITLE
various improvements to Ceylon.tmLanguage

### DIFF
--- a/Ceylon.tmLanguage
+++ b/Ceylon.tmLanguage
@@ -14,10 +14,10 @@
 	<string>^~C</string>
 	<key>name</key>
 	<string>Ceylon</string>
-	<key>patterns</key>
-	<array>
-
-		<!-- Comments -->
+	<key>repository</key>
+	<!-- Comments -->
+	<dict>
+		<key>comments</key>
 		<dict>
 			<key>begin</key>
 			<string>/\*</string>
@@ -25,8 +25,24 @@
 			<key>end</key>
 			<string>\*/</string>
 
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+			</array>
+
 			<key>name</key>
 			<string>comment.multiline.ceylon</string>
+		</dict>
+	</dict>
+	<key>patterns</key>
+	<array>
+		<!-- Comments -->
+		<dict>
+			<key>include</key>
+			<string>#comments</string>
 		</dict>
 
 		<dict>

--- a/Ceylon.tmLanguage
+++ b/Ceylon.tmLanguage
@@ -129,14 +129,66 @@
 		<!-- Literals -->
 		<dict>
 			<key>begin</key>
-			<string>("""|"|')</string>
+			<string>"""</string>
 			
 			<key>end</key>
-			<string>\1</string>
+			<string>"""</string>
+
+			<key>name</key>
+			<string>string.verbatim.ceylon</string>
+		</dict>
+
+		<dict>
+			<key>begin</key>
+			<string>'</string>
+
+			<key>end</key>
+			<string>'</string>
 
 			<key>name</key>
 			<string>string.ceylon</string>
-	
+
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>constant.character.escape.ceylon</string>
+				</dict>
+			</array>
+		</dict>
+
+		<dict>
+			<key>begin</key>
+			<string>"</string>
+
+			<key>end</key>
+			<string>"|(``)</string>
+
+			<key>name</key>
+			<string>string.template.head.ceylon</string>
+
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\.</string>
+					<key>name</key>
+					<string>constant.character.escape.ceylon</string>
+				</dict>
+			</array>
+		</dict>
+
+		<dict>
+			<key>begin</key>
+			<string>``</string>
+
+			<key>end</key>
+			<string>"|``</string>
+
+			<key>name</key>
+			<string>string.template.midOrtail.ceylon</string>
 		</dict>
 
 		<dict>

--- a/Ceylon.tmLanguage
+++ b/Ceylon.tmLanguage
@@ -61,37 +61,6 @@
 			<string>comment.shebang.ceylon</string>
 		</dict>
 
-				<!-- Import package -->
-		<dict>
-			<key>begin</key>
-			<string>^\s*(import)</string>
-			
-			<key>end</key>
-			<string>\{</string>
-
-			<key>beginCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.ceylon</string>
-				</dict>
-			</dict>
-			
-			<key>endCaptures</key>
-			<dict>
-				<key>0</key>
-				<dict>
-					<key>name</key>
-					<string>pontuation.import.ceylon</string>
-				</dict>
-			</dict>
-		
-			<key>contentName</key>
-			<string>variable.parameter.package.ceylon</string>	
-		</dict>
-
-
 		<!-- Keywords -->
 		<dict>
 			<key>match</key>

--- a/Ceylon.tmLanguage
+++ b/Ceylon.tmLanguage
@@ -86,7 +86,7 @@
 
 		<dict>
 			<key>match</key>
-			<string>\b(doc|by|license|see|throws|tagged|shared|abstract|formal|default|actual|variable|late|native|deprecated|final|sealed|annotation|suppressWarnings)\b</string>	
+			<string>\b(doc|by|license|see|throws|tagged|shared|abstract|formal|default|actual|variable|late|native|deprecated|final|sealed|annotation|suppressWarnings|static)\b</string>
 			<key>name</key>
 			<string>keyword.other.ceylon</string>
 		</dict>


### PR DESCRIPTION
This improves highlighting for

- Multiline comments
- Double quoted strings with escapes
- Single quoted chars with escaped `'`
- String templates with ``` `` ```
- Module descriptors processed by `Ceylon.tmLanguage`

The last item might be slightly controversial, but seems like a good tradeoff to me unless someone wants to provide a better fix. Unfortunately, both GitHub and VSCode fail to use the `CeylonModule.tmLanguage` file for `module.ceylon`s, and having the main `Ceylon.tmLanguage` be suitable for all `*.ceylon` files is very convenient.

Also: I didn't review any other files in the repo. Do changes to the `tmLanguage` file require any additional changes?

See https://github.com/ceylon/ceylon-highlighters/issues/15 for additional details and examples.